### PR TITLE
Fix and clean up column sorting implementation

### DIFF
--- a/script.js
+++ b/script.js
@@ -120,10 +120,8 @@ function generateTable(tableData) {
   var columnHeaders = _tr_.cloneNode(false);
   columnHeaders.appendChild(_th_.cloneNode(false));
   var columnNames = unique([].concat.apply([], rows.map(Object.keys))).sort(function(a, b) {
-    return a[1]._order < b[1]._order;
+    return getVersionOrder(a.split('/')) < getVersionOrder(b.split('/'));
   });
-  // TODO: make this cleaner, getting rid of the "order" field
-  columnNames.splice(columnNames.indexOf('_order'), 1);
   columnNames.forEach(function(c) {
     var th = _th_.cloneNode(false);
     th.setAttribute('scope', 'col');
@@ -169,7 +167,7 @@ getJSON('/view/FreeBSD/api/json?tree=jobs[name,lastCompletedBuild[result,timesta
       var arch = splitName.pop();
       var version = splitName.join('/');
       if (!tableData[arch]) {
-        tableData[arch] = {_order: getVersionOrder(splitName)};
+        tableData[arch] = {};
       }
       tableData[arch][version] = job;
     }


### PR DESCRIPTION
The current approach is confused and doesn't work. When parsing the
original JSON, the _order field is put in the per-arch entry not the
per-arch-and-version entry (and this only happens once per arch so the
value will be whatever the first version seen for it is, not that the
value ends up mattering. The generateTable function however sorts the
column names (retrieved by getting the keys for rows), which is an array
of the version strings plus the extra "_order" key that was added, but
treats the strings themselves like they're arrays of objects, calling
[1].order on them, which makes no sense and will just give undefined.
The _order field is then filtered out of the column names, which is
inconsistent with the expectation just three lines above, and is to
compensate for the bizarre way in which the field was added in the first
place. In summary, the current implementation is completely broken,
makes no sense and isn't even self-consistent. Looking back at the
history, this appears to have been broken at the time the table was
transposed (033cf379bb32bbc0b569f95a69aa94a56bf1e90b).

Instead, we can just retrieve the order by splitting the version string
when we come to compare them on '/' and calling the existing
getVersionOrder function on that list.
