### PR TITLE
show test result and change the logic of showing failing since

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <div id="loader-container">
+      <div>Loading</div>
+      <div id="loader"></div>
+    </div>
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -214,6 +214,7 @@ getJSON('/view/FreeBSD/api/json?tree=jobs[name,lastCompletedBuild[number,result,
   });
 
   generateTable(tableData);
+  document.getElementById("loader-container").remove();
   document.body.appendChild(document.createTextNode("Last updated: " + new Date()));
   document.body.appendChild(document.createElement('br'));
   document.body.appendChild(document.createTextNode("Source: "));

--- a/style.css
+++ b/style.css
@@ -38,3 +38,23 @@ i {
 .success { color: #007700; }
 .failure { color: #ff0000; }
 .unstable { color: #d1a900; }
+
+#loader-container {
+  display: flex;
+  flex-direction:row;
+}
+
+#loader {
+  margin-left: 10px;
+  border: 5px solid #f3f3f3; /* Light grey */
+  border-top: 5px solid #3b3939; /* Blue */
+  border-radius: 50%;
+  width: 10px;
+  height: 10px;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Show the test result and change the logic of showing failing since.

### Preview

![image](https://github.com/FreeBSDFoundation/jenkins-tinderbox/assets/86471511/9feede54-d350-4738-ad29-eeff2dbf6816)

### Logic of showing failing since

![image](https://github.com/FreeBSDFoundation/jenkins-tinderbox/assets/86471511/fafdee09-571a-4ab9-a6c0-e3fd85bf68cf)

The definition of color in above picture.

* Red: failed
* Blue: unstable
* Black: stable

There are four cases here.

1. First, the latest test (number 6) failed while the first fail is number 5. The test before the first fail is a success. So we can use the lastSuccessfulBuild number plus 1 to get the first failed number which is 4 + 1 = 5.
2. The second case is similar to the first case while the only difference is the status of the test before the first fail test is unstable. We still can use the lastSuccessfulBuild number plus 1 to get the first failed number because unstable is one of the statuses of 'Successful'.
3. The third and fourth cases are similar. The current status is unstable. If the test before the first fail is failed, we can use lastFailedBuild plus 1 to get the number 5.
4. If the test before the first fail is failed, we can use lastStableBuild plus 1 to get the number.

The third and the fourth case need to compare the lastFailedBuild number and lastStableBuild number to see which number is bigger. Then plus it with one to get the number 5.
